### PR TITLE
Add timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,21 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
+    },
     "@eslint/eslintrc": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
@@ -6707,6 +6722,27 @@
         "map-cache": "^0.2.2"
       }
     },
+    "framer-motion": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.4.tgz",
+      "integrity": "sha512-Bvgdwpu5UO6VnEEwenJEmnGeo9ILRRWh9f3iIX+71NiM5X60Qi6KlkBFGZc9DGbdIUAn0AYgaxVhTKL39OOYng==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.0.0-rc.20",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
+    "framesync": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
+      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
+      "requires": {
+        "hey-listen": "^1.0.5"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7077,6 +7113,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "history": {
       "version": "4.10.1",
@@ -11065,6 +11106,17 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "popmotion": {
+      "version": "9.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
+      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
+      "requires": {
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -14434,6 +14486,15 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^2.7.0"
+      }
+    },
+    "style-value-types": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
+      "integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^11.2.1",
     "@testing-library/user-event": "^12.2.2",
     "classnames": "^2.2.6",
+    "framer-motion": "^2.9.4",
     "normalize.css": "^8.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/components/Game/RoundLoop/Answer.js
+++ b/src/components/Game/RoundLoop/Answer.js
@@ -1,4 +1,3 @@
-import SimpleTimer from '../../SimpleTimer';
 import TextArea from '../../TextArea';
 import Button from '../../Button';
 import React, {useState} from 'react';
@@ -25,11 +24,6 @@ export default function InputAnswerPage (props) {
   };
   return (
     <main>
-      <SimpleTimer
-          time={10}
-          currentRoundNum={props.currentRoundNum}
-          totalRounds={props.totalRounds}
-        />
       <TextArea label="your response" placeholder="enter your response here..." maxCount={50} onChange={handleTextArea}/>
       <Button 
         confirm 

--- a/src/components/Game/RoundLoop/Choose.js
+++ b/src/components/Game/RoundLoop/Choose.js
@@ -17,11 +17,6 @@ export default function ChooseAnswerPage (props) {
 
   return (
     <>
-      <SimpleTimer
-          time={10} 
-          currentRoundNum={props.currentRoundNum}
-          totalRounds={props.totalRounds}
-        />
       <Message name={props.name} victim={props.isVictim} victimName={props.victimName}/>
       <form
         onSubmit={(event) => event.preventDefault()}>

--- a/src/components/Game/RoundLoop/roundIndex.js
+++ b/src/components/Game/RoundLoop/roundIndex.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 
 import Question from '../../Question';
-import Timer from '../../Timer';
+// import Timer from '../../Timer';
+
+import SimpleTimer from '../../SimpleTimer';
 import RoundScore from './RoundScore';
 import "../../../styles/partials/_global.scss";
 import InputAnswerPage from './Answer.js';
@@ -18,6 +20,14 @@ const REVEAL = "REVEAL";
 const ROUNDSCORE = "ROUNDSCORE";
 
 export default function RoundLoop (props) {
+  const [hideTimer, setHideTimer] = useState(false); 
+
+  useEffect(() => {
+    if(props.roundState === REVEAL) {
+      return setHideTimer(true); 
+    }
+    setHideTimer(false);
+  }, [props.roundState]);; 
 
   return (
     <div className="roundLoop">
@@ -30,7 +40,12 @@ export default function RoundLoop (props) {
           victimName={props.victimName}
           isVictim={props.isVictim}
         />
-        
+        <SimpleTimer
+          time={10} 
+          currentRoundNum={props.currentRoundNum}
+          totalRounds={props.totalRounds}
+          hide={hideTimer}
+        />
       </>}
       {props.roundState === ROUNDSCORE && <>
         <RoundScore scoreData={props.roundScoreState}/>

--- a/src/components/SimpleTimer.js
+++ b/src/components/SimpleTimer.js
@@ -35,7 +35,7 @@ export default function SimpleTimer (props) {
   return (
     
     <div className="timer-container" style={{display: display}}>
-      <p className="question-number">question {props.currentRoundNum} / {props.totalRounds}</p>
+      {/* <p className="question-number">question {props.currentRoundNum} / {props.totalRounds}</p> */}
       <div className="timer">
       <motion.div className={"timer-indicator"} initial={{width: 0}} animate={{width: indicator}} transition={{repeat: 2, duration: props.time}}></motion.div>
       </div>

--- a/src/components/SimpleTimer.js
+++ b/src/components/SimpleTimer.js
@@ -1,11 +1,13 @@
 import {useEffect, useState} from 'react';
 import "../styles/Timer.scss";
-
+import {motion} from 'framer-motion'; 
 
 export default function SimpleTimer (props) {
   const [time, setTime] = useState(props.time);
   const [display, setDisplay] = useState('flex')
-  
+  const [indicator, setIndicator] = useState(0);
+
+ let bar = "timer-indicator"; 
   useEffect(() => {
     if(props.hide) {
       return setDisplay('none'); 
@@ -14,6 +16,7 @@ export default function SimpleTimer (props) {
   }, [props.hide])
   
   useEffect(() => {
+    setIndicator(`14rem`); 
     const timer = function () {
       setTime((prev) => {
         return prev - 1; 
@@ -24,14 +27,20 @@ export default function SimpleTimer (props) {
     } else if (time === 0) {
       clearTimeout(timer); 
       setTime(props.time); 
+
     }
     
   }, [time]);
 
   return (
-    <div className="simple-timer-container" style={{display: display}}>
+    
+    <div className="timer-container" style={{display: display}}>
       <p className="question-number">question {props.currentRoundNum} / {props.totalRounds}</p>
-      <span>Time: {time}s</span>
+      <div className="timer">
+      <motion.div className={"timer-indicator"} initial={{width: 0}} animate={{width: indicator}} transition={{repeat: 2, duration: props.time}}></motion.div>
+      </div>
+      <span>{time}s</span>
     </div>
+
   ); 
 };

--- a/src/components/SimpleTimer.js
+++ b/src/components/SimpleTimer.js
@@ -33,14 +33,16 @@ export default function SimpleTimer (props) {
   }, [time]);
 
   return (
-    
-    <div className="timer-container" style={{display: display}}>
-      {/* <p className="question-number">question {props.currentRoundNum} / {props.totalRounds}</p> */}
-      <div className="timer">
-      <motion.div className={"timer-indicator"} initial={{width: 0}} animate={{width: indicator}} transition={{repeat: 2, duration: props.time}}></motion.div>
+    <article>
+      <p className="question-number" style={{display: display}}>question {props.currentRoundNum} / {props.totalRounds}</p>
+      <div className="timer-container" style={{display: display}}>
+        <div className="timer">
+        <motion.div className={"timer-indicator"} initial={{width: 0}} animate={{width: indicator}} transition={{repeat: 2, duration: props.time}}></motion.div>
+        </div>
+        <span>{time}s</span>
       </div>
-      <span>{time}s</span>
-    </div>
+    </article>
+
 
   ); 
 };

--- a/src/components/SimpleTimer.js
+++ b/src/components/SimpleTimer.js
@@ -4,19 +4,33 @@ import "../styles/Timer.scss";
 
 export default function SimpleTimer (props) {
   const [time, setTime] = useState(props.time);
-
+  const [display, setDisplay] = useState('flex')
+  
+  useEffect(() => {
+    if(props.hide) {
+      return setDisplay('none'); 
+    }
+    return setDisplay('flex'); 
+  }, [props.hide])
+  
   useEffect(() => {
     const timer = function () {
       setTime((prev) => {
         return prev - 1; 
       })
     };
-    time > 0 && setTimeout(timer, 1000);
+    if(time > 0) {
+     return setTimeout(timer, 1000);
+    } else if (time === 0) {
+      clearTimeout(timer); 
+      setTime(props.time); 
+    }
+    
   }, [time]);
 
   return (
-    <div className="simple-timer-container">
-      <p class="question-number">question {props.currentRoundNum} / {props.totalRounds}</p>
+    <div className="simple-timer-container" style={{display: display}}>
+      <p className="question-number">question {props.currentRoundNum} / {props.totalRounds}</p>
       <span>Time: {time}s</span>
     </div>
   ); 

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -19,10 +19,10 @@ export default function Timer (props) {
   return (
     <div className="timer-container">
       <p>question {props.currentRoundNum} / {props.totalRounds}</p>
-    {/* <div className="timer">
+    <div className="timer">
       <div className={bar} style={{width: `${indicator}em`,  transition: `width ${props.time}s ease-in`}}>
       </div>
-    </div> */}
+    </div>
     <span>    Time: {time}s</span>
     </div>
   ); 

--- a/src/styles/Timer.scss
+++ b/src/styles/Timer.scss
@@ -20,7 +20,7 @@
 
 
 .simple-timer-container {
-  @include flex(row, space-between); 
+  justify-content: space-between;
   width: 100%; 
   font-family: $bold-font; 
   padding-bottom: 0.75rem;

--- a/src/styles/Timer.scss
+++ b/src/styles/Timer.scss
@@ -7,7 +7,7 @@
 }
 .timer {
   height: 0.75rem; 
-  width: 18rem; // perhaps a variable here (is there a way to pass from props.width?)
+  width: 14rem; // perhaps a variable here (is there a way to pass from props.width?)
   background-color: $light-main-blue;
   border: $border-size solid $main-blue;
   margin: 1em;
@@ -18,16 +18,10 @@
   background-color: $main-blue;
 }
 
-
-.simple-timer-container {
-  justify-content: space-between;
-  width: 100%; 
-  font-family: $bold-font; 
-  padding-bottom: 0.75rem;
-  // border-bottom: 4px solid $main-blue; 
-
+article {
+  @include flex(column, flex-start, flex-start);
 }
 
 .question-number {
-  margin: 0; 
+  margin: 1em; 
 }

--- a/src/styles/Timer.scss
+++ b/src/styles/Timer.scss
@@ -10,7 +10,7 @@
   width: 14rem; // perhaps a variable here (is there a way to pass from props.width?)
   background-color: $light-main-blue;
   border: $border-size solid $main-blue;
-  margin: 1em;
+  margin: 0.5em;
 }
 
 .timer-indicator {
@@ -23,5 +23,6 @@ article {
 }
 
 .question-number {
-  margin: 1em; 
+  margin: 0 0.5em; 
+  font-family: $bold-font; 
 }


### PR DESCRIPTION
- timer starts on answer page, animates
- timer should be the same if transferred to await pages
- timer restarts / animation restarts on choose page. 
- timer display:none on reveal && roundscore
- timer starts again / animation starts again on new round
- timer is styled so question num is above. 